### PR TITLE
Move project fetch URLs to github

### DIFF
--- a/ovirt-engine-nodejs-modules.spec
+++ b/ovirt-engine-nodejs-modules.spec
@@ -1,5 +1,5 @@
 Name: ovirt-engine-nodejs-modules
-Version: 2.1.4
+Version: 2.1.5
 Release: 1%{?dist}
 Summary: Node.js modules required to build oVirt JavaScript applications
 Group: Virtualization/Management
@@ -42,6 +42,11 @@ install -m 755 `find . -maxdepth 1 -name 'yarn-*.js' -exec basename {} \;` %{des
 %{_datadir}/%{name}
 
 %changelog
+* Mon Jan 24 2022 Scott J Dickerson <sdickers@redhat.com> - 2.1.5-1
+  - Move all project fetch URLs to github
+  - Remove project 'ovirt-engine-api-explorer' since it has been deprecated for
+    over a year
+
 * Mon Dec 13 2021 Scott J Dickerson <sdickers@redhat.com> - 2.1.4-1
   Enable GitHub Actions for CI
   Remove stale pre-seeds

--- a/projects.list
+++ b/projects.list
@@ -16,15 +16,10 @@
 # See the README file for more details.
 
 # oVirt UI Extensions
-https://gerrit.ovirt.org/gitweb?p=ovirt-engine-ui-extensions.git;a=blob_plain;f={FILE};hb=HEAD
+https://raw.githubusercontent.com/oVirt/ovirt-engine-ui-extensions/master/{FILE}
 
 # ovirt-web-ui
 https://raw.githubusercontent.com/oVirt/ovirt-web-ui/master/{FILE}
 
 # cockpit-ovirt
-https://gerrit.ovirt.org/gitweb?p=cockpit-ovirt.git;a=blob_plain;f=dashboard/{FILE};hb=HEAD
-https://gerrit.ovirt.org/gitweb?p=cockpit-ovirt.git;a=blob_plain;f=dashboard/{FILE};hb=ovirt-4.3
-
-## NOTE: As of 23-Oct-20, the project has been obsoleted
-# ovirt-engine-api-explorer
-https://gerrit.ovirt.org/gitweb?p=ovirt-engine-api-explorer.git;a=blob_plain;f={FILE};hb=HEAD
+https://raw.githubusercontent.com/oVirt/cockpit-ovirt/master/dashboard/{FILE}


### PR DESCRIPTION
  - For active projects, move the fetch URLs from gerrit
    to github (the projects are either mirrored from gerrit
    to github or have been migrated to github)

  - Move depreacted project ovirt-engine-api-explorer

Change-Id: I9f75e7cceaa1f490f70aceb162a4f7c5925d6c3b
Signed-off-by: Scott J Dickerson <sdickers@redhat.com>