### PR TITLE
(demo) check action updates

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,17 +5,20 @@ on:
 jobs:
   test_el8:
     name: run check.sh to verify content
+
     runs-on: ubuntu-latest
     container:
-      image: quay.io/centos/centos:stream8
+      image: quay.io/ovirt/buildcontainer:el8stream
+
+    env:
+      # The check version script needs to know the PR base and head commits to be able to
+      # look at the contents of the range of commits for the PR. The required spec file
+      # change must be contained somewhere in one of those commits!  This env var will
+      # be picked up by the script and used as the range.
+      CHECK_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
     steps:
-      - name: enable repos and choose module versions
-        run: |
-          dnf -y copr enable ovirt/ovirt-master-snapshot centos-stream-8
-          dnf -y module enable nodejs:14
-
-      - name: install check.sh required packages
+      - name: make sure check.sh required packages are installed
         run: |
           dnf -y install git jq wget rpmlint
 
@@ -26,9 +29,6 @@ jobs:
           fetch-depth: 20
           ref: ${{ github.event.pull_request.head.sha }}
 
-      # The script needs to know the PR base and head commits to be able to look at the
-      # contents of the range of commits for the PR. The required spec file must be updated
-      # somewhere in one of those commits!
       - name: run automation/check.sh
         run: |
-          ./automation/check.sh ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+          ./automation/check.sh

--- a/automation/check-version-release.sh
+++ b/automation/check-version-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-if ! git show $1 -- *.spec | \
+if ! git show ${CHECK_RANGE:-HEAD} -- *.spec | \
     grep '^+\(Version:\|Release:\)'
 then
     echo "Package version or release must be updated"

--- a/automation/check.sh
+++ b/automation/check.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -e
 
 # Make sure we remember to update the version and/or release:
-if [[ "${1}" == "" ]] ; then
-    ./automation/check-version-release.sh HEAD
-else
-    ./automation/check-version-release.sh $1
-fi
+./automation/check-version-release.sh
 
 # Make sure we only have 1 instance of yarn
 [[ $(ls -1 yarn-*.js | wc -l) -ne 1 ]] && { echo "Error: multiple yarn binaries present"; exit 5; }


### PR DESCRIPTION
  - specify the check version's commit range via $CHECK_RANGE
  - update the action to use the ovirt build container

NOTE: With #8 merged to my repo's master branch, the "/build rpm" comment action should work.  It should run regardless as to if the PR checks pass. Right now, the check should fail since the PR commits do not include a update to the spec file.